### PR TITLE
Added Winbond W25X20

### DIFF
--- a/spiflash/types.go
+++ b/spiflash/types.go
@@ -15,6 +15,7 @@ type flashDevice struct {
 
 var devices = []flashDevice{
 	{deviceID: 0x1f65, name: "Adesto AT25DN512", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 64 * 1024},
+	{deviceID: 0x3012, name: "Winbond W25X20", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 256 * 1024},
 }
 
 func rightAlign(in uint32) (uint32, uint32) {

--- a/spiflash/types.go
+++ b/spiflash/types.go
@@ -15,7 +15,7 @@ type flashDevice struct {
 
 var devices = []flashDevice{
 	{deviceID: 0x1f65, name: "Adesto AT25DN512", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 64 * 1024},
-	{deviceID: 0x3012, name: "Winbond W25X20", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 256 * 1024},
+	{deviceID: 0xef3012, name: "Winbond W25X20", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 256 * 1024},
 }
 
 func rightAlign(in uint32) (uint32, uint32) {


### PR DESCRIPTION
Tested on JMS 579 (WD MY BOOK).
It worked perfectly.

I added WINBOND W25X20.. according to the datasheet these are the commands:

```
Write Enable (06h)
Write Disable (04h)
Read Status Register (05h)
Write Status Register (01h)
Read Data (03h)
Fast Read (0Bh)
Fast Read Dual Output (3Bh)
Page Program (02h)
Sector Erase (20h)
Block Erase (D8h)
Chip Erase (C7h)
Power-down (B9h)
Release Power-down / Device ID (ABh)
Read Manufacturer / Device ID (90h)
JEDEC ID (9Fh)
```
The datasheet also says:
`The W25X10/20/40/80 array is organized into 512/1024/2048/4096 programmable pages of 256-bytes each. Up to 256 bytes can be programmed at a time using the Page Program instruction. Pages can be erased in groups of 16 (sector erase), groups of 256 (block erase) or the entire chip (chip erase). The W25X10/20/40/80 has 32/64/128/256 erasable sectors and 2/4/8/16 erasable blocks respectively. The  small  4KB  sectors  allow  for  greater  flexibility  in  applications  that  require  data  and  parameter  storage.`

– Sector Erase (4K-bytes) – Block Erase (64K-byte) – Page program up to 256 bytes <2ms 

for more informations, the datasheet is here: https://pdf1.alldatasheet.com/datasheet-pdf/view/178188/WINBOND/W25X20.html
