### PR TITLE
Add support for Fudan Microelectronics FM25F01

### DIFF
--- a/spiflash/types.go
+++ b/spiflash/types.go
@@ -18,6 +18,7 @@ var devices = []flashDevice{
 	{deviceID: 0xef3012, name: "Winbond W25X20", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 256 * 1024},
 	{deviceID: 0x0e4012, name: "Freemont FT25H02", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 256 * 1024},
 	{deviceID: 0x0e4013, name: "Freemont FT25H04", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 512 * 1024},
+	{deviceID: 0xa13111a1, name: "Fudan Microelectronics FM25F01", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 128 * 1024},
 }
 
 func rightAlign(in uint32) (uint32, uint32) {


### PR DESCRIPTION
This chip was found in an [Orico 2580U3 "cassette" style disk enclosure](www.orico.cc/us/product/detail/7222.html).

Datasheet: https://www.fmsh.com/nvm/FM25F01_ds_eng.pdf