### PR TITLE
spiflash: Add UCUN 25HQ40 SPI flash

### DIFF
--- a/spiflash/types.go
+++ b/spiflash/types.go
@@ -19,6 +19,7 @@ var devices = []flashDevice{
 	{deviceID: 0x0e4012, name: "Freemont FT25H02", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 256 * 1024},
 	{deviceID: 0x0e4013, name: "Freemont FT25H04", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 512 * 1024},
 	{deviceID: 0xa13111a1, name: "Fudan Microelectronics FM25F01", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 128 * 1024},
+	{deviceID: 0xb36013b3, name: "UCUN 25HQ40", opcodeChipErase: 0xC7, opcodeBlockErase: 0xD8, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 512 * 1024},
 	{deviceID: 0x85401285, name: "PUYA P25Q21H", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 256 * 1024},
 	{deviceID: 0x85601385, name: "PUYA P25D40H", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 512 * 1024},
 }


### PR DESCRIPTION
Found this in my USB SATA JMS578 adapter, bought this a bit of time ago from Amazon Italy.... :-)

Theoretically all 25xx40 should have the same opcodes, anyway.