### PR TITLE
Add PUYA P25D22H flash config

### DIFF
--- a/spiflash/types.go
+++ b/spiflash/types.go
@@ -21,6 +21,7 @@ var devices = []flashDevice{
 	{deviceID: 0xa13111a1, name: "Fudan Microelectronics FM25F01", opcodeChipErase: 0xC7, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0xD8, pageSize: 256, chipSize: 128 * 1024},
 	{deviceID: 0x85401285, name: "PUYA P25Q21H", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 256 * 1024},
 	{deviceID: 0x85601385, name: "PUYA P25D40H", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 512 * 1024},
+	{deviceID: 0x85441285, name: "PUYA P25D22H", opcodeChipErase: 0x60, opcodeBlockErase: 0x20, blockSize: 4096, opcodePageErase: 0x81, pageSize: 256, chipSize: 256 * 1024},
 }
 
 func rightAlign(in uint32) (uint32, uint32) {


### PR DESCRIPTION
PUYA P25D22H is [a 2MBit flash](https://www.puyasemi.com/h_xilie743/1064.html).
I was not able to find a datasheet, thus took the one from [P25T22H linked in #10](https://github.com/BertoldVdb/jms578flash/issues/10#issue-2255015710).

I was able to flash [a glitchy USB-to-SATA adapter](https://www.ebay.de/itm/405037827911), which worked incorrectly with an 8TB HDD. Namely, it showed the correct drive size, but it was not possible to read the existing GPT partition table. Instead, a fake empty GPT was shown (very dangerous!).
Also, `smartctl -a /dev/sdb` could not read SMART information from the 8TB drive, although a 2TB drive worked fine.

After running the following steps (on a raspberry pi, but should work elsewhere), the adapter works with the 8TB HDD perfectly.
```bash
git clone --branch PUYA-P25D22H https://github.com/kabakaev/jms578flash
go build
mkdir original_firmware
./jms578flash -dumprom -unsafe -bootrom ./original_firmware/boot_rom.bin
./jms578flash -extract -firmware /tmp/fw.bin -bootrom ./original_firmware/boot_rom.bin
wget https://wiki.odroid.com/_media/odroid-xu4/software/bin-16028_jms578_std_v00.04.01.04_self_power_odd_20190611.zip
unzip bin-16028_jms578_std_v00.04.01.04_self_power_odd_20190611.zip
./jms578flash -flash -firmware "JMS578_STD_v00.04.01.04_Self Power + ODD.bin" -bootrom ./original_firmware/boot_rom.bin -unsafe -mods ClearNVRAM,FlashNoWrite
```

@ithinkido, does this PR fix your issue #10?